### PR TITLE
Add support for building Snes9X

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -121,6 +121,28 @@ supafaust() {
     popd
 }
 
+snes9x() {
+    core_name="snes9x"
+    git_name="$core_name"
+    git_repo="https://github.com/libretro/${git_name}.git"
+    core_lib="libretro/snes9x_libretro.so"
+
+    check_folder "$core_name"
+    pushd "$core_name"
+    prepare_repo "$git_name" "$git_repo"
+    pushd "$git_name"
+    apply_patches
+
+    make -C libretro platform="$BUILD_PLATFORM" clean
+    make -C libretro platform="$BUILD_PLATFORM"
+    "$STRIP" --strip-unneeded "$core_lib"
+
+    copy_lib "$core_lib"
+    make -C libretro platform="$BUILD_PLATFORM" clean
+    popd
+    popd
+}
+
 if [[ -d "$CORE_DIR" ]]; then
     # Clean previously built libraries
     if [[ -d "$BUILD_DIR" ]]; then
@@ -135,5 +157,6 @@ pushd "$CORE_DIR"
 # Enabled cores
 gambatte
 supafaust
+snes9x
 popd
 create_archive

--- a/cores/snes9x/patches/0001-libretro-snes9x-add-optimized-rk3326-platform.patch
+++ b/cores/snes9x/patches/0001-libretro-snes9x-add-optimized-rk3326-platform.patch
@@ -1,0 +1,63 @@
+From 06d01340c56b0089cedb889ed50f801e2d657e2d Mon Sep 17 00:00:00 2001
+From: Shimizu Hikaru <MuPendulum@users.noreply.github.com>
+Date: Tue, 4 Oct 2022 00:00:00 -0000
+Subject: [PATCH] libretro snes9x: add optimized rk3326 platform
+
+---
+ libretro/Makefile        | 17 +++++++++++++++--
+ libretro/Makefile.common |  5 +++++
+ 2 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/libretro/Makefile b/libretro/Makefile
+index 85fe350..f25bb09 100644
+--- a/libretro/Makefile
++++ b/libretro/Makefile
+@@ -361,6 +361,19 @@ else ifeq ($(platform), emscripten)
+    STATIC_LINKING=1
+    STATIC_LINKING_LINK=1
+ 
++# RK3326 devices
++else ifeq ($(platform), rk3326)
++   CPUFLAGS := -mcpu=cortex-a35+crypto -Ofast -fno-plt -fno-semantic-interposition -ftracer -fgcse-sm -fgcse-las -fipa-pta -DNDEBUG
++   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
++   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
++   TARGET := $(TARGET_NAME)_libretro.so
++   fpic := -fPIC
++   SHARED := -shared -Wl,--version-script=link.T
++   CFLAGS += $(CPUFLAGS) $(LTOFLAGS) $(CACHESIZES) -DUNZIP_SUPPORT
++   CXXFLAGS += $(CPUFLAGS) $(LTOFLAGS) $(CACHESIZES) -DUNZIP_SUPPORT
++   LDFLAGS += -Wl,-O1,--sort-common,--as-needed -flto=auto -static-libstdc++
++   LIBS += -lz
++
+ # Windows MSVC 2003 Xbox 1
+ else ifeq ($(platform), xbox1_msvc2003)
+ CFLAGS += -D__WIN32__
+@@ -625,8 +638,8 @@ ifneq (,$(findstring msvc,$(platform)))
+    CFLAGS += -O2 -DNDEBUG
+    CXXFLAGS += -O2 -DNDEBUG
+ else
+-   CFLAGS += -O3 -DNDEBUG
+-   CXXFLAGS += -O3 -DNDEBUG
++   CFLAGS += -DNDEBUG
++   CXXFLAGS += -DNDEBUG
+ endif
+ 
+    ifneq (,$(findstring msvc,$(platform)))
+diff --git a/libretro/Makefile.common b/libretro/Makefile.common
+index 79ae19c..7191d50 100644
+--- a/libretro/Makefile.common
++++ b/libretro/Makefile.common
+@@ -73,4 +73,9 @@ ifneq (,$(findstring win,$(platform)))
+    INCFLAGS += -I$(CORE_DIR)/unzip
+    SOURCES_C += $(CORE_DIR)/unzip/unzip.c \
+                 $(CORE_DIR)/unzip/ioapi.c
++endif
++ifneq (,$(findstring rk3326,$(platform)))
++   INCFLAGS += -I$(CORE_DIR)/unzip
++   SOURCES_C += $(CORE_DIR)/unzip/unzip.c \
++                $(CORE_DIR)/unzip/ioapi.c
+ endif
+\ No newline at end of file
+-- 
+2.37.3
+

--- a/cores/snes9x/patches/0002-libretro-snes9x-add-2.68-MHz-underclock-option.patch
+++ b/cores/snes9x/patches/0002-libretro-snes9x-add-2.68-MHz-underclock-option.patch
@@ -1,0 +1,44 @@
+From 744fd2e625a91b79f3d760feb3390b2c37a75f91 Mon Sep 17 00:00:00 2001
+From: Shimizu Hikaru <MuPendulum@users.noreply.github.com>
+Date: Tue, 4 Oct 2022 00:00:00 -0000
+Subject: [PATCH] libretro snes9x: add 2.68 MHz underclock option
+
+Reported to improve performance for SA-1 titles such as
+Kirby's Dream Land 3 and Super Mario RPG
+---
+ libretro/libretro.cpp            | 6 ++++++
+ libretro/libretro_core_options.h | 1 +
+ 2 files changed, 7 insertions(+)
+
+diff --git a/libretro/libretro.cpp b/libretro/libretro.cpp
+index 0136b60..cbaa22b 100644
+--- a/libretro/libretro.cpp
++++ b/libretro/libretro.cpp
+@@ -449,6 +449,12 @@ static void update_variables(void)
+             Settings.OneSlowClockCycle  = 6;
+             Settings.TwoClockCycles     = 12;
+         }
++        else if (strcmp(var.value, "8cycles") == 0)
++        {
++            Settings.OneClockCycle      = 8;
++            Settings.OneSlowClockCycle  = 8;
++            Settings.TwoClockCycles     = 12;
++        }
+     }
+ 
+     Settings.MaxSpriteTilesPerLine = 34;
+diff --git a/libretro/libretro_core_options.h b/libretro/libretro_core_options.h
+index d524d36..c75969d 100644
+--- a/libretro/libretro_core_options.h
++++ b/libretro/libretro_core_options.h
+@@ -223,6 +223,7 @@ struct retro_core_option_v2_definition option_defs_us[] = {
+       "hacks",
+       {
+          { "disabled",   NULL },
++         { "8cycles",    "2.68 MHz" },
+          { "light",      "Light" },
+          { "compatible", "Compatible" },
+          { "max",        "Max" },
+-- 
+2.37.3
+


### PR DESCRIPTION
Implements part of #2

Adds an untested patch for an 8 cycle downclock which is useful for some SA-1 titles
Requires zlib but build support will not be added until a later PR which will refactor the build system