### PR TITLE
crosstool-ng and variables updates

### DIFF
--- a/crosstool-ng/aarch64-rg351-linux-gnu/crosstool.config
+++ b/crosstool-ng/aarch64-rg351-linux-gnu/crosstool.config
@@ -1,9 +1,12 @@
 CT_CONFIG_VERSION="4"
+CT_STRIP_TARGET_TOOLCHAIN_EXECUTABLES=y
+CT_EXTRA_CFLAGS_FOR_BUILD="-march=x86-64-v3 -mtune=generic -O2"
+CT_EXTRA_LDFLAGS_FOR_BUILD="-Wl,-O1,--sort-common,--as-needed"
 CT_ARCH_ARM=y
-CT_ARCH_CPU="cortex-a35+crypto"
+CT_ARCH_CPU="cortex-a35+crc+crypto"
 CT_ARCH_64=y
-CT_TARGET_CFLAGS="-mcpu=cortex-a35+crypto -O2 -g -fno-plt --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256"
-CT_TARGET_LDFLAGS="-Wl,-O1,--sort-common,--as-needed"
+CT_TARGET_CFLAGS="-mcpu=cortex-a35+crc+crypto --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256 -O3 -fomit-frame-pointer -fno-plt -fno-stack-protector -fno-stack-clash-protection -fcf-protection=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
+CT_TARGET_LDFLAGS="-Wl,-O1,--sort-common,--as-needed,--hash-style=gnu,-z,norelro,-z,lazy"
 CT_TARGET_VENDOR="rg351"
 CT_KERNEL_LINUX=y
 CT_LINUX_SRC_DEVEL=y
@@ -13,11 +16,13 @@ CT_BINUTILS_LINKER_LD_GOLD=y
 CT_BINUTILS_GOLD_THREADS=y
 CT_BINUTILS_LD_WRAPPER=y
 CT_BINUTILS_PLUGINS=y
+# CT_BINUTILS_RELRO is not set
 CT_GLIBC_V_2_34=y
+# CT_GLIBC_ENABLE_DEBUG is not set
+CT_GLIBC_SSP_NO=y
 # CT_GLIBC_ENABLE_WERROR is not set
 # CT_CC_GCC_ENABLE_TARGET_OPTSPACE is not set
 CT_CC_GCC_LIBGOMP=y
-CT_CC_GCC_LIBSANITIZER=y
-CT_CC_GCC_LNK_HASH_STYLE_BOTH=y
+# CT_CC_GCC_LIBSTDCXX_VERBOSE is not set
+CT_CC_GCC_LNK_HASH_STYLE_GNU=y
 CT_CC_LANG_CXX=y
-CT_DEBUG_GDB=y

--- a/scripts/variables.sh
+++ b/scripts/variables.sh
@@ -5,6 +5,10 @@ CORE_DIR="${CURRENT_DIR}/cores"
 OUT_DIR="${CURRENT_DIR}/release"
 BUILD_PLATFORM="rk3326"
 
+DISABLE_HARDENING_CFLAGS="-fno-stack-protector -fno-stack-clash-protection -fcf-protection=none -U_FORTIFY_SOURCE -D_FORTIFY_SOURCE=0"
+DISABLE_HARDENING_LDFLAGS="-Wl,-z,norelro,-z,lazy"
+ENABLE_GRAPHITE="-fgraphite-identity -floop-nest-optimize"
+
 # $CC -v
 export BUILD_TUPLE=x86_64-build_pc-linux-gnu
 export TARGET=aarch64-rg351-linux-gnu
@@ -22,7 +26,7 @@ export NM="${TARGET}-gcc-nm"
 export OBJCOPY="${TARGET}-objcopy"
 export OBJDUMP="${TARGET}-objdump"
 export STRIP="${TARGET}-strip"
-export CFLAGS="-mcpu=cortex-a35+crc+crypto --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256 -O3 -g -fipa-pta -fno-plt -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans"
+export CFLAGS="-mcpu=cortex-a35+crc+crypto --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256 -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fno-plt -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans $ENABLE_GRAPHITE $DISABLE_HARDENING_CFLAGS"
 export CXXFLAGS="$CFLAGS"
-export LDFLAGS="-Wl,-O1,--sort-common,--as-needed -flto=auto"
+export LDFLAGS="-Wl,-O1,--sort-common,--as-needed,--hash-style=gnu $DISABLE_HARDENING_LDFLAGS -flto=auto"
 #export MAKEFLAGS="-j1"


### PR DESCRIPTION
- Disabled hardening and debugging features for the toolchain and enabled more target optimizations. The optimizations will almost certainly cause test failures.
- Disabled hardening and enabled graphite loop optimizations globally along with enabling a few optimizations.

Hardening will not be disabled in patches for obvious reasons and graphite will not be added due to it potentially generating bad code and not all toolchains enabled graphite.