### PR TITLE
Add support for building PCSX ReARMed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -27,5 +27,6 @@ picodrive
 beetlepcefast
 beetlewswan
 beetlengp
+pcsxrearmed
 popd
 create_archive

--- a/cores/pcsxrearmed/patches/0001-libretro-pcsx-rearmed-add-optimized-rk3326-platform.patch
+++ b/cores/pcsxrearmed/patches/0001-libretro-pcsx-rearmed-add-optimized-rk3326-platform.patch
@@ -1,0 +1,64 @@
+From ce81f4644967bd9b1d50515233a512d2ed78496b Mon Sep 17 00:00:00 2001
+From: Shimizu Hikaru <MuPendulum@users.noreply.github.com>
+Date: Tue, 4 Oct 2022 00:00:00 -0000
+Subject: [PATCH] libretro pcsx rearmed: add optimized rk3326 platform
+
+---
+ Makefile          |  4 ++--
+ Makefile.libretro | 18 ++++++++++++++++++
+ 2 files changed, 20 insertions(+), 2 deletions(-)
+
+diff --git a/Makefile b/Makefile
+index 87613ee..69b6ede 100644
+--- a/Makefile
++++ b/Makefile
+@@ -9,7 +9,7 @@ else
+ ifeq ($(platform), $(filter $(platform), vita ctr))
+ CFLAGS += -O3 -DNDEBUG
+ else
+-CFLAGS += -O2 -DNDEBUG
++CFLAGS += -DNDEBUG
+ endif
+ endif
+ CXXFLAGS += $(CFLAGS)
+@@ -221,7 +221,7 @@ ifeq "$(THREAD_RENDERING)" "1"
+ CFLAGS += -DTHREAD_RENDERING
+ OBJS += plugins/gpulib/gpulib_thread_if.o
+ endif
+-plugins/gpu_unai/gpulib_if.o: CFLAGS += -DREARMED -O3 
++plugins/gpu_unai/gpulib_if.o: CFLAGS += -DREARMED 
+ CC_LINK = $(CXX)
+ endif
+ 
+diff --git a/Makefile.libretro b/Makefile.libretro
+index 7b9618e..7469b6d 100644
+--- a/Makefile.libretro
++++ b/Makefile.libretro
+@@ -498,6 +498,24 @@ else ifeq ($(platform), emscripten)
+    CFLAGS += -DNO_DYLIB -DNO_SOCKET
+    STATIC_LINKING = 1
+ 
++# RK3326 and RK3399 devices
++else ifeq ($(platform),$(filter $(platform),rk3326 rk3399))
++	TARGET := $(TARGET_NAME)_libretro.so
++	ARCH := arm64
++	BUILTIN_GPU = neon
++	HAVE_NEON = 1
++	DYNAREC = ari64
++	fpic := -fPIC
++	ifeq ($(platform), rk3326)
++		CPUFLAGS := -mcpu=cortex-a35+crc+crypto --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
++	else ifeq ($(platform), rk3399)
++		CPUFLAGS := -mcpu=cortex-a72.cortex-a53+crc+crypto
++	endif
++	LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
++	CFLAGS += $(CPUFLAGS) $(LTOFLAGS) -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -DNDEBUG
++	CXXFLAGS += $(CFLAGS)
++	LDFLAGS += -Wl,-O1,--sort-common,--as-needed $(LTOFLAGS)
++
+ # Windows
+ else
+ 	TARGET := $(TARGET_NAME)_libretro.dll
+-- 
+2.38.0
+

--- a/cores/pcsxrearmed/patches/libretro-pcsx-rearmed-0002-rumble.patch
+++ b/cores/pcsxrearmed/patches/libretro-pcsx-rearmed-0002-rumble.patch
@@ -1,0 +1,26 @@
+diff --git a/frontend/libretro.c b/frontend/libretro.c
+index d0a0da7..1c20ba9 100644
+--- a/frontend/libretro.c
++++ b/frontend/libretro.c
+@@ -495,8 +495,19 @@ void plat_trigger_vibrate(int pad, int low, int high)
+ 
+    if (in_enable_vibration)
+    {
+-      rumble_cb(pad, RETRO_RUMBLE_STRONG, high << 8);
+-      rumble_cb(pad, RETRO_RUMBLE_WEAK, low ? 0xffff : 0x0);
++      int total_strength;
++      if(high > 0){
++         total_strength = 1000000 - (((double)high * 1000000) / 255.0);
++      } else if (low > 0){
++         total_strength = 100000; //We only have one motor, so this will have to do to make it weak enough
++      } else {
++         total_strength = 1000000; //turn it off
++      }
++      
++      FILE *fp;
++      fp = fopen("/sys/class/pwm/pwmchip0/pwm0/duty_cycle", "w");
++      fprintf(fp, "%u", total_strength);
++      fclose(fp);
+    }
+ }
+ 

--- a/scripts/cores.sh
+++ b/scripts/cores.sh
@@ -228,3 +228,25 @@ beetlengp() {
     popd
     popd
 }
+
+pcsxrearmed() {
+    core_name="pcsxrearmed"
+    git_name="pcsx_rearmed"
+    git_repo="https://github.com/libretro/${git_name}.git"
+    core_lib="pcsx_rearmed_libretro.so"
+
+    check_folder "$core_name"
+    pushd "$core_name"
+    prepare_repo "$git_name" "$git_repo"
+    pushd "$git_name"
+    apply_patches
+
+    make -f Makefile.libretro platform="$BUILD_PLATFORM" clean
+    make -f Makefile.libretro platform="$BUILD_PLATFORM"
+    strip_lib "$core_lib"
+
+    copy_lib "$core_lib"
+    make -f Makefile.libretro platform="$BUILD_PLATFORM" clean
+    popd
+    popd
+}


### PR DESCRIPTION
Implements part of #2 

Uses a new layout for the platform flags and defines as I was requested by AmberELEC to create a patch for pcsx.
aarch64 and will not work out-of-box for AmberELEC Sanshiro Tower due to a few scripts expecting 32-bit builds.
`-ftracer` in not included and will likely be removed globally in a future PR. Increased binary size and showed no visible improvements.