### PR TITLE
cores: disable -ftree-vectorize and -ftracer

### DIFF
--- a/cores/beetlengp/patches/0001-libretro-beetle-ngp-add-optimized-rk3326-platform.patch
+++ b/cores/beetlengp/patches/0001-libretro-beetle-ngp-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index a423a92..fb6a8af 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/beetlepcefast/patches/0001-libretro-beetle-pce-add-optimized-rk3326-platform.patch
+++ b/cores/beetlepcefast/patches/0001-libretro-beetle-pce-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index 981ea8a..4a8f8d7 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/beetlewswan/patches/0001-libretro-beetle-wonderswan-add-optimized-rk3326-plat.patch
+++ b/cores/beetlewswan/patches/0001-libretro-beetle-wonderswan-add-optimized-rk3326-plat.patch
@@ -17,7 +17,7 @@ index f8e6f4b..5e9de7e 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/gambatte/patches/0001-libretro-gambatte-add-optimized-rk3326-platform.patch
+++ b/cores/gambatte/patches/0001-libretro-gambatte-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index ffaba21..c16a23c 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/genesisplusgx/patches/0001-libretro-genesis-plus-gx-add-optimized-rk3326-platfo.patch
+++ b/cores/genesisplusgx/patches/0001-libretro-genesis-plus-gx-add-optimized-rk3326-platfo.patch
@@ -17,7 +17,7 @@ index ed92c27..65fd83c 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/mgba/patches/0001-libretro-mgba-add-optimized-rk3326-platform.patch
+++ b/cores/mgba/patches/0001-libretro-mgba-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index d6ca62ce0..ae28dd178 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/nestopia/patches/0001-libretro-nestopia-add-optimized-rk3326-platform.patch
+++ b/cores/nestopia/patches/0001-libretro-nestopia-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index f4c086b..283c98e 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+	CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++	CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +	LTOFLAGS := -fno-lto
 +	CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +	TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/pcsxrearmed/patches/0001-libretro-pcsx-rearmed-add-optimized-rk3326-platform.patch
+++ b/cores/pcsxrearmed/patches/0001-libretro-pcsx-rearmed-add-optimized-rk3326-platform.patch
@@ -52,7 +52,7 @@ index 7b9618e..7469b6d 100644
 +		CPUFLAGS := -mcpu=cortex-a72.cortex-a53+crc+crypto
 +	endif
 +	LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
-+	CFLAGS += $(CPUFLAGS) $(LTOFLAGS) -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -DNDEBUG
++	CFLAGS += $(CPUFLAGS) $(LTOFLAGS) -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +	CXXFLAGS += $(CFLAGS)
 +	LDFLAGS += -Wl,-O1,--sort-common,--as-needed $(LTOFLAGS)
 +

--- a/cores/picodrive/patches/0001-libretro-picodrive-add-optimized-rk3326-platform.patch
+++ b/cores/picodrive/patches/0001-libretro-picodrive-add-optimized-rk3326-platform.patch
@@ -31,7 +31,7 @@ index 0a859684..68454c79 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/snes9x/patches/0001-libretro-snes9x-add-optimized-rk3326-platform.patch
+++ b/cores/snes9x/patches/0001-libretro-snes9x-add-optimized-rk3326-platform.patch
@@ -18,7 +18,7 @@ index 85fe350..f25bb09 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -Ofast -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so

--- a/cores/supafaust/patches/0001-libretro-supafaust-add-optimized-rk3326-platform.patch
+++ b/cores/supafaust/patches/0001-libretro-supafaust-add-optimized-rk3326-platform.patch
@@ -17,7 +17,7 @@ index 9c0c4c6..7bfd010 100644
  
 +# RK3326 devices
 +else ifeq ($(platform), rk3326)
-+   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -ftree-vectorize -fweb -frename-registers -ftracer -DNDEBUG
++   CPUFLAGS := -mcpu=cortex-a35+crc+crypto -O3 -fomit-frame-pointer -fno-semantic-interposition -fipa-pta -fweb -frename-registers -DNDEBUG
 +   LTOFLAGS := -flto=auto -ffat-lto-objects -fdevirtualize-at-ltrans
 +   CACHESIZES := --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=256
 +   TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
When there were benefits they were small and some of the slower cores actually had very small performance hits. `-ftracer` also increased binary size.

picodrive, mgba, and pcsx rearmed all showed slight improvements with these disabled.
beetle ngp, beetle wswan, genesis plus gx, and perhaps gambatte may have shown slight benefits with them enabled but they're difficult to measure due to already being fast.

I'd rather disable these for the slower cores and reduce the risk of bad code being generated.